### PR TITLE
Make build use console-taskgraph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-user-config.yml
+user-build-config.yml
+user-deploy-config.yml
 /logs
 node_modules/
 yarn-error.log

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "console-taskgraph": "^1.0.0",
     "dockerode": "^2.5.3",
     "dot": "^1.1.2",
+    "got": "^8.3.0",
     "js-yaml": "^3.11.0",
     "json-e": "^2.5.0",
     "json-stable-stringify": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
   },
   "dependencies": {
     "commander": "^2.14.1",
+    "console-taskgraph": "^1.0.0",
     "dockerode": "^2.5.3",
     "dot": "^1.1.2",
     "js-yaml": "^3.11.0",
     "json-e": "^2.5.0",
     "json-stable-stringify": "^1.0.1",
-    "listr": "^0.13.0",
     "lodash": "^4.17.5",
     "mkdirp": "^0.5.1",
     "rimraf": "^2.6.2",

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -6,9 +6,10 @@ const {ClusterSpec} = require('../formats/cluster-spec');
 const {TaskGraph} = require('console-taskgraph');
 
 class Build {
-  constructor(input, output) {
+  constructor(input, output, cmdOptions) {
     this.input = input;
     this.output = output;
+    this.cmdOptions = cmdOptions;
 
     // TODO: make this customizable (but stable, so caching works)
     this.baseDir = '/tmp/taskcluster-installer-build';
@@ -42,6 +43,7 @@ class Build {
           spec: this.spec,
           cfg: this.cfg,
           name: service.name,
+          cmdOptions: this.cmdOptions,
         }))));
     const context = await taskgraph.run();
 
@@ -56,8 +58,8 @@ class Build {
   }
 }
 
-const main = async (input, output) => {
-  const build = new Build(input, output);
+const main = async (input, output, options) => {
+  const build = new Build(input, output, options);
   await build.run();
 };
 

--- a/src/build/service.js
+++ b/src/build/service.js
@@ -13,224 +13,104 @@ const {quote} = require('shell-quote');
 const Observable = require('zen-observable');
 const tar = require('tar-fs');
 const yaml = require('js-yaml');
-const Listr = require('listr');
 
 doT.templateSettings.strip = false;
 const ENTRYPOINT_TEMPLATE = doT.template(fs.readFileSync(path.join(__dirname, 'entrypoint.dot')));
 const DOCKERFILE_TEMPLATE = doT.template(fs.readFileSync(path.join(__dirname, 'dockerfile.dot')));
 
-class BuildService {
-  constructor(build, serviceName) {
-    this.serviceName = serviceName;
+const serviceTasks = ({baseDir, spec, cfg, name}) => {
+  const service = _.find(spec.build.services, {name});
+  const workDir = path.join(baseDir, `service-${name}`);
+  const appDir = path.join(workDir, 'app');
+  const buildpackDir = path.join(workDir, 'buildpack');
 
-    this.cfg = build.cfg;
+  const tasks = [];
+  let docker, dockerRunOpts;
 
-    this.serviceSpec = _.find(build.spec.build.services, {name: serviceName});
-    this.workDir = path.join(build.workDir, `service-${this.serviceName}`);
-    if (!fs.existsSync(this.workDir)) {
-      fs.mkdirSync(this.workDir);
-    }
+  const cleanup = async () => {
+    await Promise.all([
+      'app',
+      'buildpack',
+      'slug',
+      'docker',
+      // cache is left in place
+    ].map(dir => rimraf(path.join(workDir, dir))));
+  };
 
-    this.git = git(this.workDir);
+  const gitClone = async ({dir, url, sha, utils}) => {
+    const [source, ref] = url.split('#');
 
-    this._dockerSetup();
-
-    this.buildConfig = {
-      buildType: 'heroku-buildpack',
-      stack: 'heroku-16',
-      buildpack: 'https://github.com/heroku/heroku-buildpack-nodejs',
-    };
-  }
-
-  _dockerSetup() {
-    this.docker = new Docker();
-    // when running a docker container, always remove the container when finished, 
-    // mount the workdir at /workdir, and run as the current (non-container) user
-    // so that file ownership remains as expected.  Set up /etc/passwd and /etc/group
-    // to define names for those uid/gid, too.
-    const {uid, gid} = os.userInfo();
-    fs.writeFileSync(path.join(this.workDir, 'passwd'),
-      `root:x:0:0:root:/root:/bin/bash\nbuilder:x:${uid}:${gid}:builder:/:/bin/bash\n`);
-    fs.writeFileSync(path.join(this.workDir, 'group'),
-      `root:x:0:\nbuilder:x:${gid}:\n`);
-    this.dockerRunOpts = {
-      AutoRemove: true,
-      User: `${uid}:${gid}`,
-      Binds: [
-        `${this.workDir}/passwd:/etc/passwd:ro`,
-        `${this.workDir}/group:/etc/group:ro`,
-        `${this.workDir}:/workdir`,
-      ],
-    };
-  }
-
-  task() {
-    return {
-      title: this.serviceName,
-      task: () => new Listr([
-        {
-          title: 'Set Up',
-          task: ctx => this.setup(ctx),
-        },
-        {
-          title: 'Clean',
-          task: () => this.cleanup(),
-          skip: ctx => ctx.skip,
-        },
-        {
-          title: 'Clone service repo',
-          task: () => this.clone(),
-          skip: ctx => ctx.skip,
-        },
-        {
-          title: 'Gather build configuration',
-          task: () => this.readConfig(),
-          skip: ctx => ctx.skip,
-        },
-        {
-          title: 'Clone buildpack repo',
-          task: () => this.cloneBuildpack(),
-          skip: ctx => ctx.skip,
-        },
-        {
-          title: 'Pull build image',
-          task: () => this.pullBuildImage(),
-          skip: ctx => ctx.skip,
-        },
-        {
-          title: 'Detect',
-          task: () => this.detect(),
-          skip: ctx => ctx.skip,
-        },
-        {
-          title: 'Compile',
-          task: () => this.compile(),
-          skip: ctx => ctx.skip,
-        },
-        {
-          title: 'Generate entrypoint',
-          task: () => this.entrypoint(),
-          skip: ctx => ctx.skip,
-        },
-        {
-          title: 'Build image',
-          task: () => this.buildFinalImage(),
-          skip: ctx => ctx.skip,
-        },
-        {
-          title: 'Clean',
-          task: () => this.cleanup(),
-          skip: ctx => ctx.skip,
-        },
-      ]),
-    };
-  }
-
-  /**
-   * Set up for the build process.  This must fill out the
-   * serviceSpec.dockerImage, and set ctx.skip if there is no need to actually
-   * build the service.
-   */
-  async setup(ctx) {
-    const [source, ref] = this.serviceSpec.source.split('#');
-    const head = (await this.git.listRemote([source, ref])).split(/\s+/)[0];
-    const tag = `${this.cfg.docker.repositoryPrefix}${this.serviceName}:${head}`;
-
-    this.serviceSpec.exactSource = `${source}#${head}`;
-    this.serviceSpec.dockerImage = tag;
-
-    // set up to skip other tasks if this tag already exists locally
-    const dockerImages = await this.docker.listImages();
-    // TODO: need docker image sha, if it exists (or set it later)
-    ctx.skip = dockerImages.some(image => image.RepoTags.indexOf(tag) !== -1);
-  }
-
-  async clone() {
-    const [source, ref] = this.serviceSpec.source.split('#');
+    utils.status({message: `Cloning ${source}`});
     // TODO: update if already exists, and remove from clean step
-    if (!fs.existsSync(path.join(this.workDir, 'app'))) {
-      await this.git.clone(source, 'app', ['--depth=1', `-b${ref}`]);
+    if (!fs.existsSync(path.join(workDir, dir))) {
+      await git(workDir).clone(source, dir, ['--depth=1', `-b${ref || 'master'}`]);
     }
-    const commit = (await git(path.join(this.workDir, 'app')).revparse(['HEAD'])).trim();
-  }
+    // TODO: if sha is specified, reset to it
+  };
 
-  async readConfig() {
-    const configFile = path.join(this.workDir, 'app', '.build-config.yml');
-    if (fs.existsSync(configFile)) {
-      const config = yaml.safeLoad(configFile);
-      this.buildConfig = Object.assign({}, this.buildConfig, config);
-    }
-  }
-
-  async cloneBuildpack() {
-    const [source, ref] = this.buildConfig.buildpack.split('#');
-    // TODO: update if already exists, and remove from clean step
-    if (!fs.existsSync(path.join(this.workDir, 'buildpack'))) {
-      await this.git.clone(source, 'buildpack', ['--depth=1', `-b${ref || 'master'}`]);
-    }
-  }
-
-  async pullBuildImage() {
-    this.buildImage = `heroku/${this.buildConfig.stack.replace('-', ':')}-build`;
-
-    const stream = await new Promise((resolve, reject) => {
-      this.docker.pull(this.buildImage, (err, stream) => {
-        if (err) {
-          return reject(err);
-        }
-        resolve(stream);
-      });
-    });
-
-    // TODO: this is kind of ugly
-    return stream.pipe(split(/\r?\n/, null, {trailing: false}));
-  }
-
-  /**
-   * See https://devcenter.heroku.com/articles/buildpack-api and
-   * https://devcenter.heroku.com/articles/slug-compiler
-   *
-   * Note that this is not a general slug compiler; it ignores features
-   * that Taskcluster does not use, such as .slugignore.
-   */
-  async detect() {
+  const dockerRun = async ({logfile, command, image, utils}) => {
     const output = new PassThrough();
-    output.pipe(fs.createWriteStream(path.join(this.workDir, 'detect.log')));
+    if (logfile) {
+      output.pipe(fs.createWriteStream(path.join(workDir, logfile)));
+    }
 
-    ['cache', 'env', 'slug'].forEach(dir => {
-      if (!fs.existsSync(path.join(this.workDir, dir))) {
-        fs.mkdirSync(path.join(this.workDir, dir));
-      }
-    });
-
-    await this.docker.run(
-      this.buildImage,
-      ['workdir/buildpack/bin/detect', '/workdir/app'],
+    const runPromise = docker.run(
+      image,
+      command,
       output,
-      this.dockerRunOpts,
+      dockerRunOpts,
     );
 
-    return output.pipe(split(/\r?\n/, null, {trailing: false}));
-  }
+    await utils.waitFor(output);
+    await utils.waitFor(runPromise);
+  };
 
-  async compile() {
-    const log = path.join(this.workDir, 'compile.log');
-    const output = new PassThrough();
-    output.pipe(fs.createWriteStream(log));
+  const dockerPull = async ({image, utils}) => {
+    utils.status({message: `docker pull ${image}`});
+    const dockerStream = await new Promise(
+      (resolve, reject) => docker.pull(image, (err, stream) => err ? reject(err) : resolve(stream)));
 
-    this.docker.run(
-      this.buildImage,
-      ['/workdir/buildpack/bin/compile', '/workdir/app', '/workdir/cache', '/workdir/env'],
-      output,
-      this.dockerRunOpts,
-    );
-    return output.pipe(split(/\r?\n/, null, {trailing: false}));
-  }
+    await utils.waitFor(new Observable(observer => {
+      let downloading = {}, extracting = {}, totals = {};
+      docker.modem.followProgress(dockerStream,
+        err => err ? observer.error(err) : observer.complete(),
+        update => {
+          // The format of this stream appears undocumented, but we can fake it based on observations..
+          // general messages seem to lack progressDetail
+          if (!update.progressDetail) {
+            return;
+          }
 
-  async entrypoint() {
-    const procfilePath = path.join(this.workDir, 'app', 'Procfile');
+          let progressed = false;
+          if (update.status === 'Waiting') {
+            totals[update.id] = 104857600; // a guess: 100MB
+            progressed = true;
+          } else if (update.status === 'Downloading') {
+            downloading[update.id] = update.progressDetail.current;
+            totals[update.id] = update.progressDetail.total;
+            progressed = true;
+          } else if (update.status === 'Extracting') {
+            extracting[update.id] = update.progressDetail.current;
+            totals[update.id] = update.progressDetail.total;
+            progressed = true;
+          }
+
+          if (progressed) {
+            // calculate overall progress by assuming that every image must be
+            // downloaded and extracted, and that those both take the same amount
+            // of time per byte.
+            total = _.sum(Object.values(totals)) * 2;
+            current = _.sum(Object.values(downloading)) + _.sum(Object.values(extracting));
+            utils.status({progress: current * 100 / total});
+          }
+        });
+    }));
+  };
+
+  const writeEntrypointScript = () => {
+    const procfilePath = path.join(appDir, 'Procfile');
     if (!fs.existsSync(procfilePath)) {
-      throw new Error(`Service ${this.serviceName} has no Procfile`);
+      throw new Error(`Service ${name} has no Procfile`);
     }
     const Procfile = fs.readFileSync(procfilePath).toString();
     const procs = Procfile.split('\n').map(line => {
@@ -244,49 +124,218 @@ class BuildService {
       return {name: parts[1], command: quote([parts[2]])};
     }).filter(l => l !== null);
     const entrypoint = ENTRYPOINT_TEMPLATE({procs});
-    fs.writeFileSync(path.join(this.workDir, 'entrypoint'), entrypoint, {mode: 0o777});
-  }
+    fs.writeFileSync(path.join(workDir, 'entrypoint'), entrypoint, {mode: 0o777});
+  };
 
-  async buildFinalImage() {
-    fs.mkdirSync(path.join(this.workDir, 'docker'));
-    fs.renameSync(path.join(this.workDir, 'app'),
-      path.join(this.workDir, 'docker', 'app'));
-    fs.renameSync(path.join(this.workDir, 'entrypoint'),
-      path.join(this.workDir, 'docker', 'entrypoint'));
+  tasks.push({
+    title: `Service ${name} - Preflight`,
+    requires: [],
+    provides: [
+      `service-${name}-docker-image`, // docker image tag
+      `service-${name}-exact-source`, // exact source URL
+      `service-${name}-image-exists`, // true if the image already exists
+    ],
+    run: async (requirements, utils) => {
+      utils.step({title: 'Clean'});
+      await cleanup();
 
-    const dockerfile = DOCKERFILE_TEMPLATE({buildImage: this.buildImage});
-    fs.writeFileSync(path.join(this.workDir, 'docker', 'Dockerfile'), dockerfile);
+      utils.step({title: 'Set Up'});
 
-    const log = path.join(this.workDir, 'build.log');
-    let context = await this.docker.buildImage(
-      tar.pack(path.join(this.workDir, 'docker')),
-      {t: this.serviceSpec.dockerImage});
-    context.pipe(fs.createWriteStream(log));
-    return new Observable(observer => {
-      const onFinished = (err, output) => {
-        if (err) {
-          observer.error(new Error(err));
+      if (!fs.existsSync(workDir)) {
+        fs.mkdirSync(workDir);
+      }
+
+      ['cache', 'env', 'slug', 'docker'].forEach(dir => {
+        if (!fs.existsSync(path.join(workDir, dir))) {
+          fs.mkdirSync(path.join(workDir, dir));
         }
-        observer.complete();
-      };
-      const onProgress = event => {
-        if (event.stream) {
-          observer.next(event.stream.trimRight());
-        }
-      };
-      this.docker.modem.followProgress(context, onFinished, onProgress);
-    });
-  }
+      });
 
-  async cleanup() {
-    await Promise.all([
-      'app',
-      'buildpack',
-      'slug',
-      'docker',
-      // cache is left in place
-    ].map(dir => rimraf(path.join(this.workDir, dir))));
-  }
+      docker = new Docker();
+      // when running a docker container, always remove the container when finished, 
+      // mount the workdir at /workdir, and run as the current (non-container) user
+      // so that file ownership remains as expected.  Set up /etc/passwd and /etc/group
+      // to define names for those uid/gid, too.
+      const {uid, gid} = os.userInfo();
+      fs.writeFileSync(path.join(workDir, 'passwd'),
+        `root:x:0:0:root:/root:/bin/bash\nbuilder:x:${uid}:${gid}:builder:/:/bin/bash\n`);
+      fs.writeFileSync(path.join(workDir, 'group'),
+        `root:x:0:\nbuilder:x:${gid}:\n`);
+      dockerRunOpts = {
+        AutoRemove: true,
+        User: `${uid}:${gid}`,
+        Binds: [
+          `${workDir}/passwd:/etc/passwd:ro`,
+          `${workDir}/group:/etc/group:ro`,
+          `${workDir}:/workdir`,
+        ],
+      };
+
+      utils.step({title: 'Check for Existing Image'});
+      const [source, ref] = service.source.split('#');
+      const head = (await git(workDir).listRemote([source, ref])).split(/\s+/)[0];
+      const tag = `${cfg.docker.repositoryPrefix}${name}:${head}`;
+
+      // set up to skip other tasks if this tag already exists locally
+      const dockerImages = await docker.listImages();
+      // TODO: need docker image sha, if it exists (or set it later)
+      const dockerImageExists = dockerImages.some(image => image.RepoTags.indexOf(tag) !== -1);
+
+      // TODO: if not found locally, try to pull it
+
+      return {
+        [`service-${name}-docker-image`]: tag,
+        [`service-${name}-exact-source`]: `${source}#${head}`,
+        [`service-${name}-image-exists`]: dockerImageExists,
+      };
+    },
+  });
+
+  tasks.push({
+    title: `Service ${name} - Compile`,
+    requires: [
+      `service-${name}-docker-image`,
+      `service-${name}-image-exists`,
+      `service-${name}-exact-source`,
+    ],
+    provides: [
+      `service-${name}-built-app-dir`,
+    ],
+    run: async (requirements, utils) => {
+      const provides = {
+        [`service-${name}-built-app-dir`]: appDir,
+      };
+
+      // bail out early if we can skip this..
+      if (requirements[`service-${name}-image-exists`]) {
+        return utils.skip(provides);
+      }
+
+      utils.step({title: 'Check out Service Repo'});
+
+      await gitClone({
+        dir: 'app',
+        url: service.source,
+        utils,
+      });
+
+      utils.step({title: 'Read Build Config'});
+
+      // default buildConfig
+      buildConfig = {
+        buildType: 'heroku-buildpack',
+        stack: 'heroku-16',
+        buildpack: 'https://github.com/heroku/heroku-buildpack-nodejs',
+      };
+
+      const buildConfigFile = path.join(appDir, '.build-config.yml');
+      if (fs.existsSync(buildConfigFile)) {
+        const config = yaml.safeLoad(buildConfigFile);
+        Object.assign(buildConfig, config);
+      }
+
+      utils.step({title: 'Check out Buildpack Repo'});
+
+      await gitClone({
+        dir: 'buildpack',
+        url: buildConfig.buildpack,
+        utils,
+      });
+
+      utils.step({title: 'Pull Stack Image'});
+
+      stackImage = `heroku/${buildConfig.stack.replace('-', ':')}`;
+      await dockerPull({image: stackImage, utils});
+
+      utils.step({title: 'Pull Build Image'});
+
+      buildImage = `heroku/${buildConfig.stack.replace('-', ':')}-build`;
+      await dockerPull({image: buildImage, utils});
+
+      utils.step({title: 'Buildpack Detect'});
+
+      await dockerRun({
+        image: buildImage,
+        command: ['workdir/buildpack/bin/detect', '/workdir/app'],
+        logfile: 'detect.log',
+        utils,
+      });
+
+      utils.step({title: 'Buildpack Compile'});
+
+      await dockerRun({
+        image: buildImage,
+        command: ['workdir/buildpack/bin/compile', '/workdir/app', '/workdir/cache', '/workdir/env'],
+        logfile: 'compile.log',
+        utils,
+      });
+
+      return provides;
+    },
+  });
+
+  tasks.push({
+    title: `Service ${name} - Build Image`,
+    requires: [
+      `service-${name}-docker-image`,
+      `service-${name}-image-exists`,
+      `service-${name}-exact-source`,
+      `service-${name}-built-app-dir`,
+    ],
+    provides: [
+      `service-${name}-image-built`,
+    ],
+    run: async (requirements, utils) => {
+      const provides = {
+        [`service-${name}-image-built`]: true,
+      };
+
+      // bail out early if we can skip this..
+      if (requirements[`service-${name}-image-exists`]) {
+        return utils.skip(provides);
+      }
+
+      utils.step({title: 'Create Entrypoint Script'});
+
+      writeEntrypointScript();
+
+      utils.step({title: 'Build Final Image'});
+
+      // TODO: omit git dir, but not node_modules
+      // TODO: no need to rename, just include in tarball
+      fs.renameSync(appDir, path.join(workDir, 'docker', 'app'));
+      fs.renameSync(path.join(workDir, 'entrypoint'), path.join(workDir, 'docker', 'entrypoint'));
+
+      const dockerfile = DOCKERFILE_TEMPLATE({buildImage});
+      fs.writeFileSync(path.join(workDir, 'docker', 'Dockerfile'), dockerfile);
+
+      const log = path.join(workDir, 'build.log');
+      const tag = requirements[`service-${name}-docker-image`];
+      utils.status({progress: 0, message: `Building ${tag}`});
+      const buildStream = await docker.buildImage(
+        tar.pack(path.join(workDir, 'docker')),
+        {t: tag});
+      buildStream.pipe(fs.createWriteStream(log));
+      await utils.waitFor(new Observable(observer => {
+        docker.modem.followProgress(buildStream,
+          err => err ? observer.error(err) : observer.complete(),
+          update => {
+            if (!update.stream) {
+              return;
+            }
+            observer.next(update.stream);
+            const parts = /^Step (\d+)\/(\d+)/.exec(update.stream);
+            if (parts) {
+              utils.status({progress: 100 * parseInt(parts[1], 10) / (parseInt(parts[2], 10) + 1)});
+            }
+          });
+      }));
+
+      return provides;
+    },
+  });
+
+  return tasks;
 };
 
-exports.BuildService = BuildService;
+exports.serviceTasks = serviceTasks;

--- a/src/main.js
+++ b/src/main.js
@@ -3,8 +3,9 @@ const {version} = require('../package.json');
 
 program.version(version);
 program.command('build <input-cluster-spec> <output-cluster-spec>')
-  .action((input, output) => {
-    require('./build')(input, output).then(
+  .option('-p, --push', 'Push images to docker hub')
+  .action((input, output, options) => {
+    require('./build')(input, output, options).then(
       () => {},
       err => {
         console.error(err);

--- a/yarn.lock
+++ b/yarn.lock
@@ -36,10 +36,6 @@ ajv@^5.2.3, ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ansi-escapes@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
-
 ansi-escapes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.0.0.tgz#ec3e8b4e9f8064fc02c3ac9b65f1c275bda8ef92"
@@ -61,10 +57,6 @@ ansi-styles@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
-
-any-observable@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/any-observable/-/any-observable-0.2.0.tgz#c67870058003579009083f54ac0abafb5c33d242"
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -97,6 +89,12 @@ array-uniq@^1.0.1:
 arrify@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
+
+assert@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/assert/-/assert-1.4.1.tgz#99912d591836b5a6f5b345c0f07eefc08fc65d91"
+  dependencies:
+    util "0.10.3"
 
 assume@^1.5.2:
   version "1.5.2"
@@ -154,7 +152,7 @@ callsites@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
 
-chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
+chalk@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
   dependencies:
@@ -164,7 +162,7 @@ chalk@^1.0.0, chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.1.0:
+chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.3.2.tgz#250dc96b07491bfd601e648d66ddf5f60c7a5c65"
   dependencies:
@@ -184,28 +182,22 @@ circular-json@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
 
-cli-cursor@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
-  dependencies:
-    restore-cursor "^1.0.1"
-
-cli-cursor@^2.1.0:
+cli-cursor@^2.0.0, cli-cursor@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
     restore-cursor "^2.0.0"
 
-cli-spinners@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+cli-spinners@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-1.1.0.tgz#f1847b168844d917a671eb9d147e3df497c90d06"
 
-cli-truncate@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+cli-truncate@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-1.1.0.tgz#2b2dfd83c53cfd3572b87fc4d430a808afb04086"
   dependencies:
-    slice-ansi "0.0.4"
-    string-width "^1.0.1"
+    slice-ansi "^1.0.0"
+    string-width "^2.0.0"
 
 cli-width@^2.0.0:
   version "2.2.0"
@@ -214,10 +206,6 @@ cli-width@^2.0.0:
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
-
-code-point-at@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
 color-convert@^1.9.0:
   version "1.9.1"
@@ -257,6 +245,26 @@ concat-stream@~1.5.1:
     readable-stream "~2.0.0"
     typedarray "~0.0.5"
 
+console-taskgraph@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/console-taskgraph/-/console-taskgraph-1.0.0.tgz#cc90acd39320a5b1d2648608d23d9c4daf06d048"
+  dependencies:
+    assert "^1.4.1"
+    chalk "^2.3.2"
+    cli-spinners "^1.1.0"
+    cli-truncate "^1.1.0"
+    date-fns "^1.29.0"
+    figures "^2.0.0"
+    is-observable "^1.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    lodash "^4.17.5"
+    log-symbols "^2.2.0"
+    log-update "^2.3.0"
+    strip-ansi "^4.0.0"
+    unicode-progress "^1.0.0"
+    zen-observable "^0.8.7"
+
 core-js@^2.4.0:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.3.tgz#8acc38345824f16d8365b7c9b4259168e8ed603e"
@@ -273,7 +281,7 @@ cross-spawn@^5.1.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-date-fns@^1.27.2:
+date-fns@^1.29.0:
   version "1.29.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
@@ -341,10 +349,6 @@ doctrine@^2.1.0:
 dot@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/dot/-/dot-1.1.2.tgz#c7377019fc4e550798928b2b9afeb66abfa1f2f9"
-
-elegant-spinner@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
@@ -446,10 +450,6 @@ esutils@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.2.tgz#0abf4f1caa5bcb1f7a9d8acc6dea4faaa04bac9b"
 
-exit-hook@^1.0.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
-
 external-editor@^2.0.4:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.1.0.tgz#3d026a21b7f95b5726387d4200ac160d372c3b48"
@@ -469,13 +469,6 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
-
-figures@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
-  dependencies:
-    escape-string-regexp "^1.0.5"
-    object-assign "^4.1.0"
 
 figures@^2.0.0:
   version "2.0.0"
@@ -575,16 +568,6 @@ imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
-indent-string@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
-  dependencies:
-    repeating "^2.0.0"
-
-indent-string@^3.0.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
-
 inflight@^1.0.4:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/inflight/-/inflight-1.0.6.tgz#49bd6331d7d02d0c09bc910a1075ba8165b56df9"
@@ -595,6 +578,10 @@ inflight@^1.0.4:
 inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
+
+inherits@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.1.tgz#b17d08d326b4423e568eff719f91b0b1cbdf69f1"
 
 inquirer@^3.0.6:
   version "3.3.0"
@@ -615,27 +602,15 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-is-finite@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-finite/-/is-finite-1.0.2.tgz#cc6677695602be550ef11e8b4aa6305342b6d0aa"
-  dependencies:
-    number-is-nan "^1.0.0"
-
-is-fullwidth-code-point@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz#ef9e31386f031a7f0d643af82fde50c457ef00cb"
-  dependencies:
-    number-is-nan "^1.0.0"
-
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
 
-is-observable@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-0.2.0.tgz#b361311d83c6e5d726cabf5e250b0237106f5ae2"
+is-observable@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
   dependencies:
-    symbol-observable "^0.2.2"
+    symbol-observable "^1.1.0"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -723,70 +698,23 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-listr-silent-renderer@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
-
-listr-update-renderer@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz#344d980da2ca2e8b145ba305908f32ae3f4cc8a7"
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    elegant-spinner "^1.0.1"
-    figures "^1.7.0"
-    indent-string "^3.0.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    strip-ansi "^3.0.1"
-
-listr-verbose-renderer@^0.4.0:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz#8206f4cf6d52ddc5827e5fd14989e0e965933a35"
-  dependencies:
-    chalk "^1.1.3"
-    cli-cursor "^1.0.2"
-    date-fns "^1.27.2"
-    figures "^1.7.0"
-
-listr@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/listr/-/listr-0.13.0.tgz#20bb0ba30bae660ee84cc0503df4be3d5623887d"
-  dependencies:
-    chalk "^1.1.3"
-    cli-truncate "^0.2.1"
-    figures "^1.7.0"
-    indent-string "^2.1.0"
-    is-observable "^0.2.0"
-    is-promise "^2.1.0"
-    is-stream "^1.1.0"
-    listr-silent-renderer "^1.1.1"
-    listr-update-renderer "^0.4.0"
-    listr-verbose-renderer "^0.4.0"
-    log-symbols "^1.0.2"
-    log-update "^1.0.2"
-    ora "^0.2.3"
-    p-map "^1.1.1"
-    rxjs "^5.4.2"
-    stream-to-observable "^0.2.0"
-    strip-ansi "^3.0.1"
-
 lodash@^4.0.0, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 
-log-symbols@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+log-symbols@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-2.2.0.tgz#5740e1c5d6f0dfda4ad9323b5332107ef6b4c40a"
   dependencies:
-    chalk "^1.0.0"
+    chalk "^2.0.1"
 
-log-update@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+log-update@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/log-update/-/log-update-2.3.0.tgz#88328fd7d1ce7938b29283746f0b1bc126b24708"
   dependencies:
-    ansi-escapes "^1.0.0"
-    cli-cursor "^1.0.2"
+    ansi-escapes "^3.0.0"
+    cli-cursor "^2.0.0"
+    wrap-ansi "^3.0.1"
 
 lru-cache@^4.0.1:
   version "4.1.2"
@@ -842,11 +770,7 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-number-is-nan@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
-
-object-assign@^4.0.1, object-assign@^4.1.0:
+object-assign@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -859,10 +783,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   dependencies:
     wrappy "1"
-
-onetime@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
 onetime@^2.0.0:
   version "2.0.1"
@@ -881,22 +801,9 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-ora@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
-  dependencies:
-    chalk "^1.1.1"
-    cli-cursor "^1.0.2"
-    cli-spinners "^0.1.2"
-    object-assign "^4.0.1"
-
 os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
-
-p-map@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/p-map/-/p-map-1.2.0.tgz#e4e94f311eabbc8633a1e79908165fca26241b6b"
 
 "package@>= 1.0.0 < 1.2.0":
   version "1.0.1"
@@ -1011,12 +918,6 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
-repeating@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/repeating/-/repeating-2.0.1.tgz#5214c53a926d3552707527fbab415dbc08d06dda"
-  dependencies:
-    is-finite "^1.0.0"
-
 require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -1027,13 +928,6 @@ require-uncached@^1.0.3:
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
-
-restore-cursor@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-1.0.1.tgz#34661f46886327fed2991479152252df92daa541"
-  dependencies:
-    exit-hook "^1.0.0"
-    onetime "^1.0.0"
 
 restore-cursor@^2.0.0:
   version "2.0.0"
@@ -1063,12 +957,6 @@ rx-lite-aggregates@^4.0.8:
 rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
-
-rxjs@^5.4.2:
-  version "5.5.6"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.6.tgz#e31fb96d6fd2ff1fd84bcea8ae9c02d007179c02"
-  dependencies:
-    symbol-observable "1.0.1"
 
 safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
@@ -1107,11 +995,7 @@ simple-git@^1.89.0:
   dependencies:
     debug "^3.1.0"
 
-slice-ansi@0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
-
-slice-ansi@1.0.0:
+slice-ansi@1.0.0, slice-ansi@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-1.0.0.tgz#044f1a49d8842ff307aad6b505ed178bd950134d"
   dependencies:
@@ -1131,21 +1015,7 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
 
-stream-to-observable@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/stream-to-observable/-/stream-to-observable-0.2.0.tgz#59d6ea393d87c2c0ddac10aa0d561bc6ba6f0e10"
-  dependencies:
-    any-observable "^0.2.0"
-
-string-width@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-1.0.2.tgz#118bdf5b8cdc51a2a7e70d211e07e2b0b9b107d3"
-  dependencies:
-    code-point-at "^1.0.0"
-    is-fullwidth-code-point "^1.0.0"
-    strip-ansi "^3.0.0"
-
-string-width@^2.1.0, string-width@^2.1.1:
+string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -1162,7 +1032,7 @@ string_decoder@~1.0.3:
   dependencies:
     safe-buffer "~5.1.0"
 
-strip-ansi@^3.0.0, strip-ansi@^3.0.1:
+strip-ansi@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
@@ -1194,13 +1064,9 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-
-symbol-observable@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 table@4.0.2:
   version "4.0.2"
@@ -1282,9 +1148,19 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+unicode-progress@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unicode-progress/-/unicode-progress-1.0.0.tgz#b22db563e983fd39cd5f46c4d53e91861776e7bf"
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+
+util@0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/util/-/util-0.10.3.tgz#7afb1afe50805246489e3db7fe0ed379336ac0f9"
+  dependencies:
+    inherits "2.0.1"
 
 which@^1.2.9:
   version "1.3.0"
@@ -1295,6 +1171,13 @@ which@^1.2.9:
 wordwrap@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
+
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  dependencies:
+    string-width "^2.1.1"
+    strip-ansi "^4.0.0"
 
 wrappy@1:
   version "1.0.2"
@@ -1317,3 +1200,7 @@ yallist@^2.1.2:
 zen-observable@^0.7.1:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.7.1.tgz#f84075c0ee085594d3566e1d6454207f126411b3"
+
+zen-observable@^0.8.7:
+  version "0.8.7"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.7.tgz#2cff2f1e62ee963e43429cb2131c6d5321ec94e5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,10 @@
 # yarn lockfile v1
 
 
+"@sindresorhus/is@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
+
 JSONStream@0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-0.10.0.tgz#74349d0d89522b71f30f0a03ff9bd20ca6f12ac0"
@@ -142,6 +146,18 @@ browser-stdout@1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/browser-stdout/-/browser-stdout-1.3.1.tgz#baa559ee14ced73452229bad7326467c61fabd60"
 
+cacheable-request@^2.1.1:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/cacheable-request/-/cacheable-request-2.1.4.tgz#0d808801b6342ad33c91df9d0b44dc09b91e5c3d"
+  dependencies:
+    clone-response "1.0.2"
+    get-stream "3.0.0"
+    http-cache-semantics "3.8.1"
+    keyv "3.0.0"
+    lowercase-keys "1.0.0"
+    normalize-url "2.0.1"
+    responselike "1.0.2"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -202,6 +218,12 @@ cli-truncate@^1.1.0:
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+
+clone-response@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
+  dependencies:
+    mimic-response "^1.0.0"
 
 co@^4.6.0:
   version "4.6.0"
@@ -297,6 +319,16 @@ debug@^2.6.0:
   dependencies:
     ms "2.0.0"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
+decompress-response@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/decompress-response/-/decompress-response-3.3.0.tgz#80a4dd323748384bfa248083622aedec982adff3"
+  dependencies:
+    mimic-response "^1.0.0"
+
 deep-eql@0.1.x:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
@@ -349,6 +381,10 @@ doctrine@^2.1.0:
 dot@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/dot/-/dot-1.1.2.tgz#c7377019fc4e550798928b2b9afeb66abfa1f2f9"
+
+duplexer3@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
@@ -496,6 +532,13 @@ fn.name@1.0.x:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.0.1.tgz#8015ad149c1011a116cdb89eba4cc11d9039add8"
 
+from2@^2.1.1:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/from2/-/from2-2.3.0.tgz#8bfb5502bde4a4d36cfdeea007fcca21d7e382af"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.0.0"
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
@@ -503,6 +546,10 @@ fs.realpath@^1.0.0:
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+
+get-stream@3.0.0, get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 glob@7.1.2, glob@^7.0.3, glob@^7.0.5, glob@^7.1.2:
   version "7.1.2"
@@ -530,6 +577,28 @@ globby@^5.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+got@^8.3.0:
+  version "8.3.0"
+  resolved "https://registry.yarnpkg.com/got/-/got-8.3.0.tgz#6ba26e75f8a6cc4c6b3eb1fe7ce4fec7abac8533"
+  dependencies:
+    "@sindresorhus/is" "^0.7.0"
+    cacheable-request "^2.1.1"
+    decompress-response "^3.3.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    into-stream "^3.1.0"
+    is-retry-allowed "^1.1.0"
+    isurl "^1.0.0-alpha5"
+    lowercase-keys "^1.0.0"
+    mimic-response "^1.0.0"
+    p-cancelable "^0.4.0"
+    p-timeout "^2.0.1"
+    pify "^3.0.0"
+    safe-buffer "^5.1.1"
+    timed-out "^4.0.1"
+    url-parse-lax "^3.0.0"
+    url-to-options "^1.0.1"
+
 graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
@@ -552,9 +621,23 @@ has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
 
+has-symbol-support-x@^1.4.1:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
+
+has-to-string-tag-x@^1.2.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz#a045ab383d7b4b2012a00148ab0aa5f290044d4d"
+  dependencies:
+    has-symbol-support-x "^1.4.1"
+
 he@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+http-cache-semantics@3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz#39b0e16add9b605bf0a9ef3d9daaf4843b4cacd2"
 
 iconv-lite@^0.4.17:
   version "0.4.19"
@@ -575,7 +658,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
@@ -602,9 +685,20 @@ inquirer@^3.0.6:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
+into-stream@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
+  dependencies:
+    from2 "^2.1.1"
+    p-is-promise "^1.1.0"
+
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
 
 is-observable@^1.1.0:
   version "1.1.0"
@@ -628,6 +722,10 @@ is-path-inside@^1.0.0:
   dependencies:
     path-is-inside "^1.0.1"
 
+is-plain-obj@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
+
 is-promise@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
@@ -635,6 +733,10 @@ is-promise@^2.1.0:
 is-resolvable@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
+
+is-retry-allowed@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
 
 is-stream@^1.1.0:
   version "1.1.0"
@@ -652,6 +754,13 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
 
+isurl@^1.0.0-alpha5:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/isurl/-/isurl-1.0.0.tgz#b27f4f49f3cdaa3ea44a0a5b7f3462e6edc39d67"
+  dependencies:
+    has-to-string-tag-x "^1.2.0"
+    is-object "^1.0.1"
+
 js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -662,6 +771,10 @@ js-yaml@^3.10.0, js-yaml@^3.11.0, js-yaml@^3.9.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+json-buffer@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
 
 json-e@^2.5.0:
   version "2.5.0"
@@ -691,6 +804,12 @@ jsonparse@0.0.5:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-0.0.5.tgz#330542ad3f0a654665b778f3eb2d9a9fa507ac64"
 
+keyv@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
+  dependencies:
+    json-buffer "3.0.0"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -716,6 +835,10 @@ log-update@^2.3.0:
     cli-cursor "^2.0.0"
     wrap-ansi "^3.0.1"
 
+lowercase-keys@1.0.0, lowercase-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
+
 lru-cache@^4.0.1:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.2.tgz#45234b2e6e2f2b33da125624c4664929a0224c3f"
@@ -726,6 +849,10 @@ lru-cache@^4.0.1:
 mimic-fn@^1.0.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
+
+mimic-response@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.0.tgz#df3d3652a73fded6b9b0b24146e6fd052353458e"
 
 minimatch@^3.0.2, minimatch@^3.0.4:
   version "3.0.4"
@@ -770,7 +897,15 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
 
-object-assign@^4.0.1:
+normalize-url@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-2.0.1.tgz#835a9da1551fa26f70e92329069a23aa6574d7e6"
+  dependencies:
+    prepend-http "^2.0.0"
+    query-string "^5.0.1"
+    sort-keys "^2.0.0"
+
+object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -805,6 +940,24 @@ os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
+p-cancelable@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/p-cancelable/-/p-cancelable-0.4.0.tgz#bcb41d35bf6097fc4367a065b6eb84b9b124eff0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
+
+p-is-promise@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
+
+p-timeout@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-2.0.1.tgz#d8dd1979595d2dc0139e1fe46b8b646cb3cdf038"
+  dependencies:
+    p-finally "^1.0.0"
+
 "package@>= 1.0.0 < 1.2.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/package/-/package-1.0.1.tgz#d25a1f99e2506dcb27d6704b83dca8a312e4edcc"
@@ -825,6 +978,10 @@ pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
+pify@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-3.0.0.tgz#e5a4acd2c101fdf3d9a4d07f0dbc4db49dd28176"
+
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"
@@ -842,6 +999,10 @@ pluralize@^7.0.0:
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+
+prepend-http@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -869,6 +1030,14 @@ pump@^1.0.0:
   dependencies:
     end-of-stream "^1.1.0"
     once "^1.3.1"
+
+query-string@^5.0.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
 
 readable-stream@^2.0.0, readable-stream@^2.0.5:
   version "2.3.3"
@@ -929,6 +1098,12 @@ resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
 
+responselike@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-1.0.2.tgz#918720ef3b631c5642be068f15ade5a46f4ba1e7"
+  dependencies:
+    lowercase-keys "^1.0.0"
+
 restore-cursor@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
@@ -958,7 +1133,7 @@ rx-lite@*, rx-lite@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
 
-safe-buffer@~5.1.0, safe-buffer@~5.1.1:
+safe-buffer@^5.1.1, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
@@ -1001,6 +1176,12 @@ slice-ansi@1.0.0, slice-ansi@^1.0.0:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
 
+sort-keys@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-2.0.0.tgz#658535584861ec97d730d6cf41822e1f56684128"
+  dependencies:
+    is-plain-obj "^1.0.0"
+
 split-ca@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split-ca/-/split-ca-1.0.1.tgz#6c83aff3692fa61256e0cd197e05e9de157691a6"
@@ -1014,6 +1195,10 @@ split@^1.0.1:
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
 
 string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
   version "2.1.1"
@@ -1119,6 +1304,10 @@ through@2, "through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
+timed-out@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/timed-out/-/timed-out-4.0.1.tgz#f32eacac5a175bea25d7fab565ab3ed8741ef56f"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -1151,6 +1340,16 @@ typedarray@^0.0.6, typedarray@~0.0.5:
 unicode-progress@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unicode-progress/-/unicode-progress-1.0.0.tgz#b22db563e983fd39cd5f46c4d53e91861776e7bf"
+
+url-parse-lax@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-lax/-/url-parse-lax-3.0.0.tgz#16b5cafc07dbe3676c1b1999177823d6503acb0c"
+  dependencies:
+    prepend-http "^2.0.0"
+
+url-to-options@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/url-to-options/-/url-to-options-1.0.1.tgz#1505a03a289a48cbd7a434efbaeec5055f5633a9"
 
 util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This splits each service into three tasks, with the idea that the
compile / build-image split will allow generation of clients in between.

OK, OK, this doesn't really do anything new, but it's the basis of some new stuff.  I'll merge shortly if there's no objection.