### PR TITLE
Bug 1452000 - disable monitoring

### DIFF
--- a/taskcluster-spec/deploy.yml
+++ b/taskcluster-spec/deploy.yml
@@ -43,6 +43,8 @@ resources:
               value: 'false'
             - name: TRUST_PROXY  # TODO
               value: 'false'
+            - name: MONITORING_ENABLE
+              value: 'false'
             ports:
             - containerPort: 80
 


### PR DESCRIPTION
Admittedly, this is for the tc-ping service which is no longer being built, but this is the idea behind how we'll handle statsum/sentry in r13y for the moment.