### PR TITLE
Opt for using exec for git and other things

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "recursive-copy": "^2.0.9",
     "rimraf": "^2.6.2",
     "shell-quote": "^1.6.1",
-    "simple-git": "^1.89.0",
     "split": "^1.0.1",
     "tar-fs": "^1.16.0",
     "tar-stream": "^1.5.5",

--- a/src/build/index.js
+++ b/src/build/index.js
@@ -8,7 +8,6 @@ const mkdirp = util.promisify(require('mkdirp'));
 const {ClusterSpec} = require('../formats/cluster-spec');
 const {TaskGraph} = require('console-taskgraph');
 const {gitClone} = require('./utils');
-const git = require('simple-git/promise');
 const generateRepoTasks = require('./repo');
 
 const _kindTaskGenerators = {

--- a/src/build/other.js
+++ b/src/build/other.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const path = require('path');
 const split = require('split');
 const rimraf = util.promisify(require('rimraf'));
-const git = require('simple-git/promise');
 const doT = require('dot');
 const {quote} = require('shell-quote');
 const yaml = require('js-yaml');

--- a/src/build/repo.js
+++ b/src/build/repo.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const path = require('path');
 const rimraf = util.promisify(require('rimraf'));
 const mkdirp = util.promisify(require('mkdirp'));
-const git = require('simple-git/promise');
 const libDocs = require('taskcluster-lib-docs');
 const {gitClone, stampDir, dirStamped} = require('./utils');
 

--- a/src/build/service.js
+++ b/src/build/service.js
@@ -70,8 +70,6 @@ const generateServiceTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => 
         utils,
         baseDir,
       });
-
-      return provides;
     },
   });
 };

--- a/src/build/service.js
+++ b/src/build/service.js
@@ -61,7 +61,7 @@ const generateServiceTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => 
       }
 
       if (requirements[`service-${name}-image-on-registry`]) {
-        throw new Error(`Image ${tag} already exists on the registry; not pushing`);
+        return utils.skip({});
       }
 
       await dockerPush({

--- a/src/build/service.js
+++ b/src/build/service.js
@@ -6,7 +6,6 @@ const path = require('path');
 const split = require('split');
 const rimraf = util.promisify(require('rimraf'));
 const mkdirp = util.promisify(require('mkdirp'));
-const git = require('simple-git/promise');
 const doT = require('dot');
 const {quote} = require('shell-quote');
 const yaml = require('js-yaml');

--- a/src/build/utils.js
+++ b/src/build/utils.js
@@ -1,5 +1,6 @@
+const util = require('util');
 const _ = require('lodash');
-const git = require('simple-git/promise');
+const exec = util.promisify(require('child_process').execFile);
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -53,25 +54,24 @@ exports.stampDir = ({dir, sources}) => {
  */
 exports.gitClone = async ({dir, url, sha, utils}) => {
   const [repo, ref = 'master'] = url.split('#');
+  const opts = {cwd: dir};
 
   if (!fs.existsSync(dir)) {
-    await git('/').clone(repo, dir, ['--depth=1', `-b${ref}`]);
-    const exactRev = (await git(dir).revparse(['HEAD'])).split(/\s+/)[0];
-    return {exactRev, changed: true};
+    await exec('git', ['clone', repo, dir, '--depth=1', '-b', ref]);
+    const exactRev = (await exec('git', ['rev-parse', 'HEAD'], opts)).stdout;
+    return {exactRev: exactRev.split(/\s+/)[0], changed: true};
   }
 
-  const existingRev = (await git(dir).revparse(['HEAD'])).split(/\s+/)[0];
-  // note: this is often empty -- https://github.com/steveukx/git-js/pull/252
-  const remoteRev = (await git(dir).listRemote([repo, ref])).split(/\s+/)[0];
+  const existingRev = (await exec('git', ['rev-parse', 'HEAD'], opts)).stdout.split(/\s+/)[0];
+  const remoteRev = (await exec('git', ['ls-remote', repo, ref])).stdout.split(/\s+/)[0];
 
   if (existingRev === remoteRev) {
     return {exactRev: existingRev, changed: false};
   }
 
-  await git(dir).fetch([repo, ref]);
-  await git(dir).reset(['--hard', 'FETCH_HEAD']);
-
-  const exactRev = (await git(dir).revparse(['HEAD'])).split(/\s+/)[0];
+  await exec('git', ['fetch', repo, ref], opts);
+  await exec('git', ['reset', '--hard', 'FETCH_HEAD'], opts);
+  const exactRev = (await exec('git', ['rev-parse', 'HEAD'], opts)).stdout.split(/\s+/)[0];
   return {exactRev, changed: true};
 };
 

--- a/src/build/utils.js
+++ b/src/build/utils.js
@@ -1,5 +1,6 @@
 const util = require('util');
 const _ = require('lodash');
+const split = require('split');
 const exec = util.promisify(require('child_process').execFile);
 const fs = require('fs');
 const os = require('os');

--- a/yarn.lock
+++ b/yarn.lock
@@ -1606,12 +1606,6 @@ signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
-simple-git@^1.89.0:
-  version "1.89.0"
-  resolved "https://registry.yarnpkg.com/simple-git/-/simple-git-1.89.0.tgz#ef52fe734d5060566ce187b2bbace36c2323e34c"
-  dependencies:
-    debug "^3.1.0"
-
 slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"


### PR DESCRIPTION
This was initially just work to get the git bits to function better but ran into some other issues too. Most controversial will probably be the bit where I allow skipping previously pushed images since when a single service updates or this crashes halfway though, you want to be able to push the rest of them. If there's a better way to solve that, let's do it the other way instead.