### PR TITLE
Bug 1452767 - better dependency tracking

### DIFF
--- a/docs/build-implementation.md
+++ b/docs/build-implementation.md
@@ -25,7 +25,11 @@ To make this tractable, a task's outputs are not to be modified by any other tas
 This occasionally requires copying data that might otherwise be used in-place, but this is generally a small cost.
 In particular, builds are never performed directly in repository clones; instead, the data is copied to a fresh directory first.
 
-The `directoryStamped `and `stampDirectory` utility functions make it simple to identify a directory that is the product of a task taking a given set of inputs.
+The `Stamp` class helps ensure this.
+Its constructor takes a bit of information about the executing step, along with a sequence of inputs to the step.
+Some of those inputs can be other Stamp instances.
+It then provides `dirStamped `and `stampDir` methods to make it simple to identify a directory that is the product of those inputs.
+It also provides a `hash` method to produce a short hash based on those inputs.
 
 ## Dependencies
 
@@ -33,7 +37,10 @@ Dependency names follow some patterns:
 
 * `repo-${name}-dir` -- the directory in which a repository has been checked out
 * `repo-${name}-exact-source` -- the exact source URL for the repository
+* `repo-${name}-stamp` -- the Stamp instance for this repository
 * `docker-image-${image}` -- the named Docker image is available in the local Docker daemon
 * `docs-${name}-dir` -- the directory containing documentation for the named repository; this will always be `${workDir}/docs/${name}`, allowing mounting `${workDir}/docs` in a docker image if necessary.
+* `docs-${name}-stamp` -- the Stamp instance for the docs dir
+* `service-${name}-stamp` -- the Stamp instance for the built service
 * `service-${name}-docker-image` -- the built Docker image for the named service
 * `service-${name}-image-on-registry` -- true if the docker image for the named service is already present on the Docker registry

--- a/src/build/repo.js
+++ b/src/build/repo.js
@@ -5,7 +5,8 @@ const path = require('path');
 const rimraf = util.promisify(require('rimraf'));
 const mkdirp = util.promisify(require('mkdirp'));
 const libDocs = require('taskcluster-lib-docs');
-const {gitClone, stampDir, dirStamped} = require('./utils');
+const Stamp = require('./stamp');
+const {gitClone} = require('./utils');
 
 const generateRepoTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => {
   const repository = _.find(spec.build.repositories, {name});
@@ -15,6 +16,7 @@ const generateRepoTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => {
     provides: [
       `repo-${name}-dir`, // full path of the repository
       `repo-${name}-exact-source`, // exact source URL for the repository
+      `repo-${name}-stamp`,
     ],
     locks: ['git'],
     run: async (requirements, utils) => {
@@ -26,9 +28,12 @@ const generateRepoTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => {
       });
 
       const [repoUrl] = repository.source.split('#');
+      const stamp = new Stamp({step: 'repo-clone', version: 1},
+        `${repoUrl}#${exactRev}`);
       const provides = {
         [`repo-${name}-dir`]: repoDir,
         [`repo-${name}-exact-source`]: `${repoUrl}#${exactRev}`,
+        [`repo-${name}-stamp`]: stamp,
       };
 
       if (changed) {
@@ -48,20 +53,26 @@ const generateRepoTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => {
     requires: [
       `repo-${name}-dir`,
       `repo-${name}-exact-source`,
+      `repo-${name}-stamp`,
     ],
     provides: [
       `docs-${name}-dir`, // full path of the docs dir
+      `docs-${name}-stamp`,
     ],
     run: async (requirements, utils) => {
       // note that docs directory paths must have this form (${basedir}/docs is
       // mounted in docker images)
       const docsDir = path.join(baseDir, 'docs', name);
       const repoDir = requirements[`repo-${name}-dir`];
+
+      const stamp = new Stamp({step: 'repo-docs', version: 1},
+        requirements[`repo-${name}-stamp`]);
       const provides = {
         [`docs-${name}-dir`]: docsDir,
+        [`docs-${name}-stamp`]: stamp,
       };
 
-      if (dirStamped({dir: docsDir, sources: requirements[`repo-${name}-exact-source`]})) {
+      if (stamp.dirStamped(docsDir)) {
         return utils.skip({provides});
       }
 
@@ -78,7 +89,7 @@ const generateRepoTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => {
       });
       await documentor.write({docsDir});
 
-      stampDir({dir: docsDir, sources: requirements[`repo-${name}-exact-source`]});
+      stamp.stampDir(docsDir);
       return provides;
     },
   });

--- a/src/build/service/docs-dockerfile.dot
+++ b/src/build/service/docs-dockerfile.dot
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:alpine
 
 COPY nginx-site.conf /etc/nginx/conf.d/default.conf
 COPY app /app

--- a/src/build/service/tools-ui.js
+++ b/src/build/service/tools-ui.js
@@ -9,7 +9,7 @@ const tar = require('tar-fs');
 const copy = require('recursive-copy');
 const Stamp = require('../stamp');
 const {dockerRun, dockerPull, dockerImages, dockerBuild, dockerRegistryCheck,
-  ensureDockerImage} = require('../utils');
+  ensureDockerImage, serviceDockerImageTask} = require('../utils');
 
 doT.templateSettings.strip = false;
 const TOOLS_UI_DOCKERFILE_TEMPLATE = doT.template(fs.readFileSync(path.join(__dirname, 'tools-ui-dockerfile.dot')));
@@ -79,48 +79,17 @@ exports.toolsUiTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions, repository
     },
   });
 
-  tasks.push({
-    title: `Service ${name} - Build Image`,
+  serviceDockerImageTask({tasks, baseDir, workDir, cfg, name,
     requires: [
-      `service-${name}-stamp`,
       `service-${name}-installed-app-dir`,
+      `docker-image-${nodeImage}`,
     ],
-    provides: [
-      `service-${name}-docker-image`, // docker image tag
-      `service-${name}-image-on-registry`, // true if the image already exists on registry
-    ],
-    locks: ['docker'],
-    run: async (requirements, utils) => {
+    makeTarball: (requirements, utils) => {
       const appDir = requirements[`service-${name}-installed-app-dir`];
-      const serviceStamp = requirements[`service-${name}-stamp`];
-      const tag = `${cfg.docker.repositoryPrefix}${name}:${serviceStamp.hash()}`;
-
-      utils.step({title: 'Check for Existing Images'});
-
-      const imageLocal = (await dockerImages({baseDir}))
-        .some(image => image.RepoTags && image.RepoTags.indexOf(tag) !== -1);
-      const imageOnRegistry = await dockerRegistryCheck({tag});
-
-      const provides = {
-        [`service-${name}-docker-image`]: tag,
-        [`service-${name}-image-on-registry`]: imageOnRegistry,
-      };
-
-      // bail out if we can, pulling the image if it's only available remotely
-      if (!imageLocal && imageOnRegistry) {
-        await dockerPull({image: tag, utils, baseDir});
-        return utils.skip({provides});
-      } else if (imageLocal) {
-        return utils.skip({provides});
-      }
-
-      // build a tarfile containing the build directory, Dockerfile, and ancillary files
-      utils.step({title: 'Create Docker-Build Tarball'});
-
       const dockerfile = TOOLS_UI_DOCKERFILE_TEMPLATE({nodeImage});
       const nginxConf = fs.readFileSync(path.join(__dirname, 'tools-ui-nginx-site.conf'));
 
-      const tarball = tar.pack(appDir, {
+      return tar.pack(appDir, {
         finalize: false,
         map: header => {
           header.name = `app/${header.name}`;
@@ -132,18 +101,6 @@ exports.toolsUiTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions, repository
           pack.finalize();
         },
       });
-
-      utils.step({title: 'Building'});
-
-      await dockerBuild({
-        tarball,
-        logfile: `${workDir}/docker-build.log`,
-        tag,
-        utils,
-        baseDir,
-      });
-
-      return provides;
     },
   });
 };

--- a/src/build/stamp.js
+++ b/src/build/stamp.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const {isEqual, cloneDeep} = require('lodash');
+const stableStringify = require('json-stable-stringify');
+
+/**
+ * Represents a "stamp" for a build step, encapsulating all of the inputs
+ * to that step
+ */
+class Stamp {
+  /**
+   * Create a new stamp.  The given version is an integer giving the version of this
+   * step; bump that if the step implementation changes.  The remaining arguments are
+   * the inputs to this step, either other Stamp objects or arbitrary data.
+   */
+  constructor({step, version}, ...inputs) {
+    this.data = [{step, version}];
+    inputs.forEach(input => {
+      if (input instanceof Stamp) {
+        this.data.push(cloneDeep(input.data));
+      } else {
+        this.data.push(cloneDeep(input));
+      }
+    });
+  }
+
+  /**
+   * Get a hash of this stamp
+   */
+  hash() {
+    return crypto.createHash('sha256')
+      .update(stableStringify(this.data), 'utf-8')
+      .digest('hex')
+      .slice(0, 12);
+  }
+
+  /**
+   * Mark this directory as having been generated with this stamp.  Call this when
+   * the step is complete.
+   */
+  stampDir(dir) {
+    const sourcesFile = path.join(dir, '.sources.json');
+    fs.writeFileSync(sourcesFile, stableStringify(this.data));
+  }
+
+  /**
+   * Return true if the given directory has already been generated with a
+   * matching stamp.
+   */
+  dirStamped(dir) {
+    if (!fs.existsSync(dir)) {
+      return false;
+    }
+
+    const sourcesFile = path.join(dir, '.sources.json');
+    if (!fs.existsSync(sourcesFile)) {
+      return false;
+    }
+
+    const foundData = JSON.parse(fs.readFileSync(sourcesFile, {encoding: 'utf-8'}));
+    if (!isEqual(foundData, this.data)) {
+      return false;
+    }
+
+    return true;
+  }
+}
+
+module.exports = Stamp;

--- a/src/build/utils.js
+++ b/src/build/utils.js
@@ -341,7 +341,7 @@ exports.serviceDockerImageTask = ({tasks, baseDir, workDir, cfg, name, requires,
     locks: ['docker'],
     run: async (requirements, utils) => {
       const serviceStamp = requirements[`service-${name}-stamp`];
-      const tag = `${cfg.docker.repositoryPrefix}${name}:${serviceStamp.hash()}`;
+      const tag = `${cfg.docker.repositoryPrefix}${name}:SVC-${serviceStamp.hash()}`;
 
       utils.step({title: 'Check for Existing Images'});
 

--- a/src/build/utils.js
+++ b/src/build/utils.js
@@ -12,35 +12,6 @@ const got = require('got');
 const {spawn} = require('child_process'); 
 
 /**
- * Determine if the given directory is stamped with the given sources.
- */
-exports.dirStamped = ({dir, sources}) => {
-  if (!fs.existsSync(dir)) {
-    return false;
-  }
-
-  const sourcesFile = path.join(dir, '.sources.json');
-  if (!fs.existsSync(sourcesFile)) {
-    return false;
-  }
-
-  const foundSources = JSON.parse(fs.readFileSync(sourcesFile, {encoding: 'utf-8'}));
-  if (!_.isEqual(foundSources, sources)) {
-    return false;
-  }
-
-  return true;
-};
-
-/**
- * Stamp a directory as having been created with the given sources
- */
-exports.stampDir = ({dir, sources}) => {
-  const sourcesFile = path.join(dir, '.sources.json');
-  fs.writeFileSync(sourcesFile, JSON.stringify(sources));
-};
-
-/**
  * Perform a git clone
  *
  * - dir -- directory to clone to


### PR DESCRIPTION
This mainly introduces a "Stamp" class that can track recursive dependencies rather than just tracking repo hashes (although those are at the leaves of the dependency tree).  It also enables bumpable "version" numbers so if we change a build step we can just  bump its version number.

Using this updated info, we can generate shorter hashes for each image.  I also added a `SVC-` prefix just to differentiate them from docker image IDs.