### PR TITLE
Bug 1465769 - build the tc-references service too

### DIFF
--- a/docs/build-implementation.md
+++ b/docs/build-implementation.md
@@ -39,7 +39,7 @@ Dependency names follow some patterns:
 * `repo-${name}-exact-source` -- the exact source URL for the repository
 * `repo-${name}-stamp` -- the Stamp instance for this repository
 * `docker-image-${image}` -- the named Docker image is available in the local Docker daemon
-* `docs-${name}-dir` -- the directory containing documentation for the named repository; this will always be `${workDir}/docs/${name}`, allowing mounting `${workDir}/docs` in a docker image if necessary.
+* `docs-${name}-dir` -- the directory containing documentation for the named repository; this will always be `${baseDir}/docs/${name}`, allowing mounting `${baseDir}/docs` in a docker image if necessary.
 * `docs-${name}-stamp` -- the Stamp instance for the docs dir
 * `service-${name}-stamp` -- the Stamp instance for the built service
 * `service-${name}-docker-image` -- the built Docker image for the named service

--- a/src/build/service.js
+++ b/src/build/service.js
@@ -9,6 +9,7 @@ const {dockerPush} = require('./utils');
 const {herokuBuildpackTasks} = require('./service/heroku-buildpack');
 const {toolsUiTasks} = require('./service/tools-ui');
 const {docsTasks} = require('./service/docs');
+const {referencesTasks} = require('./service/references');
 
 const generateServiceTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => {
   const repository = _.find(spec.build.repositories, {name});
@@ -28,6 +29,10 @@ const generateServiceTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => 
 
     case 'docs':
       docsTasks({tasks, baseDir, spec, cfg, name, cmdOptions, repository, workDir});
+      break;
+
+    case 'references':
+      referencesTasks({tasks, baseDir, spec, cfg, name, cmdOptions, repository, workDir});
       break;
 
     default:

--- a/src/build/service/docs.js
+++ b/src/build/service/docs.js
@@ -125,6 +125,7 @@ exports.docsTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions, repository, w
 
   serviceDockerImageTask({tasks, baseDir, workDir, cfg, name,
     requires: [
+      `service-${name}-stamp`,
       `service-${name}-static-dir`,
       'docker-image-nginx:alpine',
     ],

--- a/src/build/service/heroku-buildpack.js
+++ b/src/build/service/heroku-buildpack.js
@@ -169,6 +169,7 @@ exports.herokuBuildpackTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions, re
 
   serviceDockerImageTask({tasks, baseDir, workDir, cfg, name,
     requires: [
+      `service-${name}-stamp`,
       `service-${name}-built-app-dir`,
       `docker-image-${stackImage}`,
     ],

--- a/src/build/service/references.js
+++ b/src/build/service/references.js
@@ -1,0 +1,36 @@
+const util = require('util');
+const path = require('path');
+const rimraf = util.promisify(require('rimraf'));
+const tar = require('tar-fs');
+const {serviceDockerImageTask} = require('../utils');
+
+exports.referencesTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions, repository, workDir}) => {
+  const docNames = spec.build.repositories.filter(repo => repo.docs).map(repo => repo.name);
+
+  // This service has its own Dockerfile, so we just run the `docker build`.
+  serviceDockerImageTask({tasks, baseDir, workDir, cfg, name,
+    requires: [
+      `repo-${name}-stamp`,
+      `repo-${name}-dir`,
+      ...docNames.map(name => `docs-${name}-dir`),
+      ...docNames.map(name => `docs-${name}-stamp`),
+    ],
+    makeTarball: (requirements, utils) => {
+      const repoDir = requirements[`repo-${name}-dir`];
+
+      return tar.pack(repoDir, {
+        finalize: false,
+        finish: pack => {
+          // all of the docs are in baseDir/docs, so just use that as input/.
+          tar.pack(path.join(baseDir, 'docs'), {
+            map: header => {
+              header.name = `input/${header.name}`;
+              return header;
+            },
+            pack,
+          });
+        },
+      });
+    },
+  });
+};

--- a/src/build/service/tools-ui-dockerfile.dot
+++ b/src/build/service/tools-ui-dockerfile.dot
@@ -78,4 +78,4 @@ COPY nginx-site.conf /etc/nginx/conf.d/default.conf
 COPY app /app
 
 # on start, run `yarn build` before starting nginx
-CMD ["sh", "-c", "cd /app && yarn build && exec nginx -g daemon off;"]
+CMD ["sh", "-c", "cd /app && yarn build && exec nginx -g 'daemon off;'"]

--- a/src/build/service/tools-ui.js
+++ b/src/build/service/tools-ui.js
@@ -81,6 +81,7 @@ exports.toolsUiTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions, repository
 
   serviceDockerImageTask({tasks, baseDir, workDir, cfg, name,
     requires: [
+      `service-${name}-stamp`,
       `service-${name}-installed-app-dir`,
       `docker-image-${nodeImage}`,
     ],

--- a/taskcluster-spec/build.yml
+++ b/taskcluster-spec/build.yml
@@ -123,6 +123,16 @@ repositories:
     node: 8
   source: https://github.com/taskcluster/taskcluster-tools#redeploy
 
+# references (and schemas)
+- name: references
+  kind: service
+  docs:
+    tier: integrations
+  service:
+    buildtype: references
+    node: 8
+  source: https://github.com/taskcluster/taskcluster-references#master
+
 # docs/metadata sources that are not compiled into the final product
 
 # operations


### PR DESCRIPTION
![screenshot from 2018-06-01 19-50-58](https://user-images.githubusercontent.com/28673/40867782-1dda7680-65d5-11e8-8f04-b4b43ad28226.png)

This includes a minor refactor of serviceDockerImageTask so that it can handle the case where we build a docker image straight out of a repo.  Please also review https://github.com/taskcluster/taskcluster-references -- it's pretty dead simple and well-tested.