### PR TITLE
Bug 1459751 - set explicit projectName for some repos

### DIFF
--- a/docs/cluster-spec.md
+++ b/docs/cluster-spec.md
@@ -24,6 +24,7 @@ The docs property, if an object, has properties:
 
 * `tier` -- the documentation tier for this repository
 * `menuIndex` -- (optional) the sorting order for this item in the docs index
+* `projectName` -- (optional) the projectName under which to list the project
 
 The following kinds are defined:
 

--- a/src/build/repo.js
+++ b/src/build/repo.js
@@ -66,6 +66,7 @@ const generateRepoTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => {
       const repoDir = requirements[`repo-${name}-dir`];
 
       const stamp = new Stamp({step: 'repo-docs', version: 1},
+        {config: repository.docs},
         requirements[`repo-${name}-stamp`]);
       const provides = {
         [`docs-${name}-dir`]: docsDir,
@@ -80,7 +81,7 @@ const generateRepoTasks = ({tasks, baseDir, spec, cfg, name, cmdOptions}) => {
       await mkdirp(path.dirname(docsDir));
 
       const documentor = await libDocs.documenter({
-        project: name,
+        project: repository.docs.projectName || name,
         readme: path.join(repoDir, 'README.md'),
         docsFolder: path.join(repoDir, 'docs'),
         tier: repository.docs.tier,

--- a/taskcluster-spec/build.yml
+++ b/taskcluster-spec/build.yml
@@ -108,6 +108,7 @@ repositories:
   kind: service
   docs:
     tier: integrations
+    projectName: taskcluster-docs
   service:
     buildtype: docs
     node: 9
@@ -118,6 +119,7 @@ repositories:
   kind: service
   docs:
     tier: integrations
+    projectName: taskcluster-tools
   service:
     buildtype: tools-ui
     node: 8
@@ -128,6 +130,7 @@ repositories:
   kind: service
   docs:
     tier: integrations
+    projectName: taskcluster-references
   service:
     buildtype: references
     node: 8


### PR DESCRIPTION
These three repos have generated docs (meaning tc-installer runs tc-lib-docs for them) so they need an explicit projectName configured.