### PR TITLE
Don't treat a binary stream as utf-8

### DIFF
--- a/src/build/utils.js
+++ b/src/build/utils.js
@@ -138,7 +138,6 @@ exports.dockerRun = async ({baseDir, logfile, command, env, binds, workingDir, i
   // docker API calls.
   const container = await docker.createContainer(containerOpts);
   const stream = await container.attach({stream: true, stdout: true, stderr: true});
-  stream.setEncoding('utf-8');
   stream.pipe(output, {end: true});
   await container.start({});
 


### PR DESCRIPTION
The stream is binary, not utf-8, and trying to process it as utf-8 occasionally inserts `bd bf` into the stream when it sees an invalid utf-8 byte sequence.  Which causes all manner of garbage to get stuck into the console.

I discovered this a few weeks ago and thought I had fixed it already, but the line is still here so apparently I didn't!